### PR TITLE
Fix: purchasable nullpointer

### DIFF
--- a/src/services/Commerce.php
+++ b/src/services/Commerce.php
@@ -173,8 +173,13 @@ class Commerce extends Component
         $product = null;
         $purchasable = $lineItem->purchasable;
 
-        $eventItem->setItemName($purchasable->title ?? $lineItem->getDescription());
-        $eventItem->setItemId($purchasable->getSku() ?? $lineItem->getSku());
+        if ($purchasable === null) {
+            $eventItem->setItemName($lineItem->getDescription());
+            $eventItem->setItemId($lineItem->getSku());
+        } else {
+            $eventItem->setItemName($purchasable->title ?? $lineItem->getDescription());
+            $eventItem->setItemId($purchasable->getSku() ?? $lineItem->getSku());
+        }
         $eventItem->setPrice($lineItem->salePrice);
         $eventItem->setQuantity($lineItem->qty);
 


### PR DESCRIPTION
### Description

Hi I ran into this problem with a client of mine who kept locking themselves out of the frontend of their website as they were removing product variants they were no longer stocking on their website. 
It seems that the Purchasable Object can be null on a LineItem if the product variant has been deleted in the backend while still being in basket of a user.  This will throw an error if the code is trying to execute getSku() on a null object. 

When rendering the cart on the frontend Craft Commerce will automatically remove them from the basket and trigger a RemoveFromCart event which will then call this method into which I added the nullpointer check. 

### Related issues
